### PR TITLE
dedup customElements.define

### DIFF
--- a/nuxeo-elements-sample/package-lock.json
+++ b/nuxeo-elements-sample/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@lrnwebcomponents/deduping-fix": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@lrnwebcomponents/deduping-fix/-/deduping-fix-4.0.0.tgz",
+      "integrity": "sha512-++MM/E4zN1Id52JV6P2O4EhGL/56AZ1Oq9H1wDWKU4JmNDIgZVYEv0kwmFJ5ldXfJS/N3hQchaUhkkXSZk8iKA=="
+    },
     "@nuxeo/nuxeo-elements": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/@nuxeo/nuxeo-elements/-/nuxeo-elements-3.0.8.tgz",

--- a/nuxeo-elements-sample/package.json
+++ b/nuxeo-elements-sample/package.json
@@ -13,6 +13,7 @@
     "test:integration": "polymer build # test that psk builds without error with the CLI"
   },
   "dependencies": {
+    "@lrnwebcomponents/deduping-fix": "^4.0.0",
     "@nuxeo/nuxeo-elements": "^3.0.8",
     "@polymer/app-layout": "^3.0.0-pre.15",
     "@polymer/app-route": "^3.0.0-pre.15",

--- a/nuxeo-elements-sample/src/my-app.js
+++ b/nuxeo-elements-sample/src/my-app.js
@@ -22,6 +22,7 @@ import '@polymer/iron-pages/iron-pages.js';
 import '@polymer/iron-selector/iron-selector.js';
 import '@polymer/paper-icon-button/paper-icon-button.js';
 import './my-icons.js';
+import '@lrnwebcomponents/deduping-fix/deduping-fix.js';
 
 // Gesture events like tap and track generated from touch will not be
 // preventable, allowing for better scrolling performance.


### PR DESCRIPTION
The goal here is to fix the issue
```
Uncaught (in promise) DOMException: Failed to execute 'define' on 'CustomElementRegistry': the name "dom-module" has already been used with this registry
```
This doesn't happen on Web UI. It happens only with the Polymer Starter Kit because it is using dynamic imports. This would most likely be fixed if the starter kit was using more modern build tooling.

The fix consists of simply preventing the `customElement.define` from breaking the app if an element is being defined twice.